### PR TITLE
Revert "bump quasar compatability to 2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quasar-app-extension-system-environment-variables",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Loads environment variables from the system and makes them available through process.env. Works best for building on CI/CD environments",
   "author": "marcorivm <marcorivm@gmail.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const extendWithDotenv = function (api, conf) {
 
 module.exports = function (api) {
   // quasar compatibility check
-  api.compatibleWith('@quasar/app', '>1.0.0')
+  api.compatibleWith('@quasar/app', '^1.0.0')
 
   api.extendQuasarConf((conf) => {
     extendWithDotenv(api, conf)


### PR DESCRIPTION
https://github.com/marcorivm/quasar-app-extension-system-environment-variables/pull/2 needs to be applied before we can have quasar 2.0 compatibility and that's a breaking change, so we need to make a release for 1.0.1 and then another release 2.0.0 with support for quasar 2.0 and no support for 1.0